### PR TITLE
uses a connect script to centralize database connection

### DIFF
--- a/Database/CleanArchive.py
+++ b/Database/CleanArchive.py
@@ -1,10 +1,11 @@
-from pymongo import MongoClient
+from Database.Connect import connect
+
 from datetime import datetime, timedelta
 from collections import Counter
 import pytz
 import re
 
-db = MongoClient('localhost', 27017).WallStreetDB
+db = connect()
 
 
 def clean(all=True):

--- a/Database/Connect.py
+++ b/Database/Connect.py
@@ -1,0 +1,11 @@
+from pymongo import MongoClient
+
+db = None
+
+def connect():
+    global db
+    if db is None:
+        db = MongoClient('localhost', 27017).WallStreetDB
+        return db
+    else:
+        return db

--- a/Database/CreateViews.py
+++ b/Database/CreateViews.py
@@ -1,6 +1,6 @@
-from pymongo import MongoClient
+from Database.Connect import connect
 
-db = MongoClient('localhost', 27017).WallStreetDB
+db = connect()
 
 
 def createCleanedIndex():

--- a/Database/StoreArchive.py
+++ b/Database/StoreArchive.py
@@ -1,7 +1,7 @@
 # import FetchArchive as fetch
 from Database import FetchArchive as fetch
+from Database.Connect import connect
 
-from pymongo import MongoClient
 import os
 import logging
 from concurrent import futures
@@ -10,7 +10,7 @@ if not os.path.exists('logs'):
     os.makedirs('logs')
 logging.basicConfig(filename='logs/StoreArchive.log', level=logging.INFO, format='%(asctime)s:%(levelname)s:%(message)s')
 
-db = MongoClient('localhost', 27017).WallStreetDB
+db = connect()
 
 
 def buildIndex(network):


### PR DESCRIPTION
Now all processes will share the same connection. This won't necessarily improve performance, but it will improve maintainability. When/If we switch to a remote database, we only have to modify 1 line to point the program to the new database location.